### PR TITLE
Created Settings Page with dark/light mode feature

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="testRunner" value="PLATFORM" />
+        <option name="disableWrapperSourceDistributionNotification" value="true" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleJvm" value="1.8" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 
     // FirebaseUI
     implementation 'com.firebaseui:firebase-ui-auth:6.4.0'
+    implementation 'androidx.preference:preference:1.1.1'
 
 
     testImplementation 'junit:junit:4.+'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <activity android:name=".ui.settingsPage.SettingsActivity"></activity>
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/binduhait/friendlychat/MainActivity.java
+++ b/app/src/main/java/com/binduhait/friendlychat/MainActivity.java
@@ -22,6 +22,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.binduhait.friendlychat.ui.settingsPage.SettingsActivity;
 import com.firebase.ui.auth.AuthUI;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
@@ -104,9 +105,6 @@ public class MainActivity extends AppCompatActivity {
         List<FriendlyMessage> friendlyMessages = new ArrayList<>();
         mMessageAdapter = new MessageAdapter(this, R.layout.item_message, friendlyMessages);
         mMessageListView.setAdapter(mMessageAdapter);
-
-        // Initialize progress bar
-        mProgressBar.setVisibility(ProgressBar.INVISIBLE);
 
         // ImagePickerButton shows an image picker to upload a image for a message
         mPhotoPickerButton.setOnClickListener(new View.OnClickListener() {
@@ -191,7 +189,6 @@ public class MainActivity extends AppCompatActivity {
         super.onActivityResult(requestCode, resultCode, data);
         if (requestCode == RC_SIGN_IN && resultCode == RESULT_OK) {
             Toast.makeText(this, "Signed in!", Toast.LENGTH_SHORT).show();
-            mProgressBar.setVisibility(View.VISIBLE);
         } else if (resultCode == RESULT_CANCELED) {
             Toast.makeText(this, "Sign in canceled!", Toast.LENGTH_SHORT).show();
         } else if (requestCode == RC_PHOTO_PICKER && resultCode == RESULT_OK) {
@@ -249,16 +246,21 @@ public class MainActivity extends AppCompatActivity {
                 AuthUI.getInstance().signOut(this);
                 return true;
             case R.id.settings_menu:{
-                Toast.makeText(this,"Settings - Under-development",Toast.LENGTH_SHORT)
-                        .show();
+                openSettingsPage();
+                return true;
             }
             case R.id.my_profile_menu:{
                 Toast.makeText(this,"My Profile-Under-development",Toast.LENGTH_SHORT)
                         .show();
+                return true;
             }
             default:
                 return super.onOptionsItemSelected(item);
         }
+    }
+
+    private void openSettingsPage() {
+        startActivity(new Intent(MainActivity.this, SettingsActivity.class));
     }
 
     private void onSignedInInitialize(String username) {
@@ -289,6 +291,7 @@ public class MainActivity extends AppCompatActivity {
             };
             mMessagesDatabaseReference.addChildEventListener(mChildEventListener);
         }
+        else mProgressBar.setVisibility(View.INVISIBLE);
     }
 
     private void detachDatabaseReadListener() {

--- a/app/src/main/java/com/binduhait/friendlychat/ui/settingsPage/SettingsActivity.java
+++ b/app/src/main/java/com/binduhait/friendlychat/ui/settingsPage/SettingsActivity.java
@@ -1,0 +1,23 @@
+package com.binduhait.friendlychat.ui.settingsPage;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.os.Bundle;
+
+import com.binduhait.friendlychat.R;
+
+public class SettingsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_settings);
+
+        if (savedInstanceState == null) {
+            getSupportFragmentManager()
+                    .beginTransaction()
+                    .replace(R.id.settings, new SettingsFragment())
+                    .commit();
+        }
+    }
+}

--- a/app/src/main/java/com/binduhait/friendlychat/ui/settingsPage/SettingsActivity.java
+++ b/app/src/main/java/com/binduhait/friendlychat/ui/settingsPage/SettingsActivity.java
@@ -11,6 +11,7 @@ public class SettingsActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setTitle("Settings");
         setContentView(R.layout.activity_settings);
 
         if (savedInstanceState == null) {

--- a/app/src/main/java/com/binduhait/friendlychat/ui/settingsPage/SettingsFragment.java
+++ b/app/src/main/java/com/binduhait/friendlychat/ui/settingsPage/SettingsFragment.java
@@ -1,0 +1,64 @@
+package com.binduhait.friendlychat.ui.settingsPage;
+
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatDelegate;
+import androidx.preference.CheckBoxPreference;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.SwitchPreference;
+import androidx.preference.SwitchPreferenceCompat;
+import com.binduhait.friendlychat.R;
+
+public class SettingsFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceChangeListener {
+
+    @Override
+    public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
+        setPreferencesFromResource(R.xml.root_preferences, rootKey);
+
+        SwitchPreferenceCompat switchPreference = findPreference("theme_toggle");
+        switchPreference.setOnPreferenceChangeListener(this);
+        findPreference("notification_enable").setOnPreferenceChangeListener(this);
+
+        //to set switchPreference default value
+        switchPreference.setChecked(currentSystemTheme() == 2);
+
+    }
+
+    @Override
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+
+        if (preference instanceof SwitchPreferenceCompat) {
+            if (preference.getKey().equals("theme_toggle")) {
+                if (((SwitchPreferenceCompat) preference).isChecked()) {
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+                }
+                else {
+                    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+                }
+            }
+        }
+        else if(preference instanceof CheckBoxPreference){
+            if(preference.getKey().equals("notification_enable")){
+                if (((CheckBoxPreference)preference).isChecked()) {
+                    Toast.makeText(getContext(),"Notifications Disabled",Toast.LENGTH_SHORT).show();
+                }
+                else {
+                    Toast.makeText(getContext(),"Notifications Enabled",Toast.LENGTH_SHORT).show();
+                }
+            }
+        }
+        return true;
+    }
+
+    private int currentSystemTheme(){
+        switch (getResources().getConfiguration().uiMode
+                & Configuration.UI_MODE_NIGHT_MASK) {
+            case Configuration.UI_MODE_NIGHT_NO: return 1; //1 for light mode
+            case Configuration.UI_MODE_NIGHT_YES: return 2; //2 for dark mode
+        }
+        return 0;
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -54,6 +54,7 @@
 
     <ProgressBar
         android:id="@+id/progressBar"
+        android:visibility="gone"
         style="?android:attr/progressBarStyleLarge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.settingsPage.SettingsActivity">
+
+    <FrameLayout
+        android:id="@+id/settings"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>

--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,0 +1,23 @@
+<PreferenceScreen xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <PreferenceCategory
+        app:iconSpaceReserved="false"
+        app:title="General">
+
+        <SwitchPreferenceCompat
+            app:iconSpaceReserved="false"
+            app:key="theme_toggle"
+            app:summaryOff="Light"
+            app:summaryOn="Dark"
+            app:title="Theme" />
+
+        <CheckBoxPreference
+            app:defaultValue="true"
+            app:iconSpaceReserved="false"
+            app:key="notification_enable"
+            app:summaryOff="Disabled"
+            app:summaryOn="Enabled"
+            app:title="Notification" />
+    </PreferenceCategory>
+
+</PreferenceScreen>


### PR DESCRIPTION
* Now app has a settings page where it has two settings - Theme mode changer switch and Notification on/off check box.
* On switching on or off the theme mode changer switch, theme of the app changes accordingly.
* On enabling or disabling the notification on/off check box, Toast message pops up.
Commit 2:
* Added SettingsActivity title as "Settings".
![Screenshots_demo](https://user-images.githubusercontent.com/59572531/106324105-97703480-629e-11eb-865d-ddc50583d115.png)

